### PR TITLE
Update Readme to remove es6 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Brunch + Babel/ES6
+# Brunch SASS
 
-This is a modern JS skeleton for [Brunch](http://brunch.io).
+This is a modern sass skeleton for [Brunch](http://brunch.io).
 
 ## Installation
 
-Clone this repo manually or use `brunch new dir -s brunch/with-es6`
+Clone this repo manually
 
 ## Getting started
 
@@ -13,16 +13,12 @@ Clone this repo manually or use `brunch new dir -s brunch/with-es6`
     * [Brunch](http://brunch.io): `npm install -g brunch`
     * Brunch plugins and app dependencies: `npm install`
 * Run:
-    * `brunch watch --server` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).
+    * `brunch watch --s` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).
+    * Default href localhost:3333
     * `brunch build --production` — builds minified project for production
 * Learn:
     * `public/` dir is fully auto-generated and served by HTTP server.  Write your code in `app/` dir.
     * Place static files you want to be copied from `app/assets/` to `public/`.
     * [Brunch site](http://brunch.io), [Getting started guide](https://github.com/brunch/brunch-guide#readme)
 
-## ES7
 
-To use proposed JS features not included into ES6, do this:
-
-* `npm install --save-dev babel-preset-stage-0`
-* in `brunch-config.js`, add the preset: `presets: ['es2015', 'stage-0']`


### PR DESCRIPTION
 Babel and es6 were included in the orginal project setup using a brunch skeleton. They are no longer being used.